### PR TITLE
Fixed broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Nature of Code book project
 
-Hello.  If you found your way here you have found the raw source material for my Nature of Code book.  The book is not yet for sale, but will be soon in PDF and print forms at [natureofcode.com](http:://www.natureofcode.com).  There, you'll also find a free version of the book available as HTML.  
+Hello.  If you found your way here you have found the raw source material for my Nature of Code book.  The book is not yet for sale, but will be soon in PDF and print forms at [natureofcode.com](http://www.natureofcode.com).  There, you'll also find a free version of the book available as HTML.  
 
 You may notice that all of the book's content is here -- illustrations, source code, raw text (ASCIIDOC files), and well as design elements (CSS).  The book is licensed under the [Creative Commons Attribution-NonCommercial 3.0 Unported License](http://creativecommons.org/licenses/by-nc/3.0/).  You are free to share and remix the book, as long as you provide attribution and do not attempt to re-sell.
 


### PR DESCRIPTION
Fixed broken link to www.natureofcode.com in README.md due to extra colon in "http://".
