### PR TITLE
Fix FlowField.pde location

### DIFF
--- a/raw/chapters/06_steering.asc
+++ b/raw/chapters/06_steering.asc
@@ -704,7 +704,7 @@ class FlowField {
 
 So let’s assume we have a [klass]*FlowField* object called “flow”.  Using the [function]*lookup()* function above, our vehicle can then retrieve a desired vector from the flow field and use Reynolds’s rules (steering = desired - velocity) to calculate a steering force.
 
-image::imgs/chapter06/ch06_ex4.png[canvas="processingjs/chapter06/_6_04_Flowfield/_6_04_FlowField.pde processingjs/chapter06/_6_04_Flowfield/FlowField.pde processingjs/chapter06/_6_04_Flowfield/Vehicle.pde",classname="screenshot"]
+image::imgs/chapter06/ch06_ex4.png[canvas="processingjs/chapter06/_6_04_Flowfield/_6_04_Flowfield.pde processingjs/chapter06/_6_04_Flowfield/FlowField.pde processingjs/chapter06/_6_04_Flowfield/Vehicle.pde",classname="screenshot"]
 
 [[chapter06_example4]]
 [example]*Example 6.4: Flow field following* 


### PR DESCRIPTION
FlowField is camelCased

Or maybe the pde should be changed to Flowfield.pde to match the directory name; your call.

Flow field is two words so camel case seems to make sense.
