### PR TITLE
Fix for 2 (tiny) typos in chapter 9

### DIFF
--- a/raw/chapters/09_ga.asc
+++ b/raw/chapters/09_ga.asc
@@ -85,7 +85,7 @@ Now, it’s worth noting that this problem (_arrive at the phrase “to be or no
 
 [source,java]
 ----
-string s = "To be or not to be that is the question";
+String s = "to be or not to be that is the question";
 println(s);
 ----
 


### PR DESCRIPTION
This fixes 2 very tiny typos.

When talking about monkeys eventually typing out "to be or not to be," and how it's a silly example, the example sketch has 2 problems:
1. the java class String was lower-cased: `string s = "...";`
2. the sentence, which was supposed to only have lower-case letters and spaces, started with a capital T

This fixes both of those.
