### PR TITLE
Fixed code error on p. 412 (DNA-class)

### DIFF
--- a/raw/chapters/09_ga.asc
+++ b/raw/chapters/09_ga.asc
@@ -762,7 +762,7 @@ class DNA {
   
   //[full] Crossover
   DNA crossover(DNA partner) {
-    DNA child = new DNA(genes.length);
+    DNA child = new DNA();
     int midpoint = int(random(genes.length));
     for (int i = 0; i < genes.length; i++) {
       if (i > midpoint) child.genes[i] = genes[i];


### PR DESCRIPTION
There's no DNA constructor with an int-argument as it is called in the crossover-function. So this code failed to compile (when you're lazy like me and just copied and pasted it).
I just removed `genes.length` from the constructor at the instantiation of `child`.

P.S. thanks for that great work. It's a pleasure to read through it.
