### PR TITLE
Changed two typos regarding 'convex' and 'concave'.

### DIFF
--- a/raw/chapters/05_physicslib.asc
+++ b/raw/chapters/05_physicslib.asc
@@ -1215,7 +1215,7 @@ image::imgs/chapter05/ch05_06.png[classname="half-width-left",alt="Figure 5.6"]
 
 . *Order of vertices!*  If you are thinking in terms of pixels (as above) the vertices should be defined in counterclockwise order.  (When they are translated to Box2D World vectors, they will actually be in clockwise order since the vertical axis is flipped.)  
 
-. *Convex shapes only!*  A concave shape is one where the surface curves inward. Convex is the opposite (see illustration below).  Note how in a concave shape every internal angle must be 180 degrees or less.  Box2D is not capable of handling collisions for concave shapes.  If you need a concave shape, you will have to build one out of multiple convex shapes (more about that in a moment).
+. *Convex shapes only!*  A concave shape is one where the surface curves inward. Convex is the opposite (see illustration below).  Note how in a convex shape every internal angle must be 180 degrees or less.  Box2D is not capable of handling collisions for concave shapes.  If you need a concave shape, you will have to build one out of multiple convex shapes (more about that in a moment).
 
 ((("Box2D","concave shapes and")))
 
@@ -1258,7 +1258,7 @@ Now, when it comes time to display the shape in Processing, we can no longer jus
 [[chapter05_exercise4]]
 .Exercise 5.4
 ==============================
-Using the [klass]*PolygonShape* class, create your own polygon design (remember, it must be concave).  Some possibilities below.
+Using the [klass]*PolygonShape* class, create your own polygon design (remember, it must be convex).  Some possibilities below.
 
 image::imgs/chapter05/ch05_exc04.png[]
 


### PR DESCRIPTION
Explanation and exercise contained two typos regarding 'convex' and 'concave', also noted in issue #321 and one line in #332.
