### PR TITLE
wrong variable name in code sample

### DIFF
--- a/raw/chapters/03_oscillation.asc
+++ b/raw/chapters/03_oscillation.asc
@@ -1265,7 +1265,7 @@ In Figure 3.17, we can see that if we stretch the spring beyond its rest length,
 // Magnitude of spring force according to Hooke’s law
 float k = 0.1;
 PVector force = PVector.sub(bob,anchor);
-float currentLength = dir.mag();
+float currentLength = force.mag();
 float x = restLength - currentLength;
 
 // Direction of spring force (unit vector)


### PR DESCRIPTION
Should be `force` instead of `dist` from the previous example.
