### PR TITLE
Fix .pde link (Kochline -> KochLine -- CameCase was missing).

### DIFF
--- a/raw/chapters/08_fractals.asc
+++ b/raw/chapters/08_fractals.asc
@@ -640,7 +640,7 @@ image::imgs/chapter08/ch08_18.png[alt="Figure 8.18"]
 
 Putting it all together, if we call [function]*generate()* five times in [function]*setup()*, we’ll see the following result.
 
-image::imgs/chapter08/ch08_ex05.png[canvas="processingjs/chapter08/_8_05_Koch/_8_05_Koch.pde processingjs/chapter08/_8_05_Koch/KochFractal.pde processingjs/chapter08/_8_05_Koch/Kochline.pde",classname="screenshot"]
+image::imgs/chapter08/ch08_ex05.png[canvas="processingjs/chapter08/_8_05_Koch/_8_05_Koch.pde processingjs/chapter08/_8_05_Koch/KochFractal.pde processingjs/chapter08/_8_05_Koch/KochLine.pde",classname="screenshot"]
 
 [[chapter08_example5]]
 [example]*Example 8.5: Koch curve* 


### PR DESCRIPTION
This code snippet should now run properly in the HTML version.
