### PR TITLE
Changed "brightest" to "darkest", to sync with Example I.4

### DIFF
--- a/raw/chapters/00_7_intro.asc
+++ b/raw/chapters/00_7_intro.asc
@@ -543,7 +543,7 @@ void draw() {
 }
 ----
 
-By drawing the ellipses on top of each other with some transparency, we can actually see the distribution.  The brightest spot is near the center, where most of the values cluster, but every so often circles are drawn farther to the right or left of the center.
+By drawing the ellipses on top of each other with some transparency, we can actually see the distribution.  The darkest spot is near the center, where most of the values cluster, but every so often circles are drawn farther to the right or left of the center.
 
 [[intro_exercise4]]
 .Exercise I.4


### PR DESCRIPTION
The circles used in this example are black (with transparency), so as they accumulate near the mean (the center point), they become dark.

Yet the text here refers to the "lightest" point.  I think it should be "darkest".
